### PR TITLE
Tweaking note styles

### DIFF
--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -56,6 +56,8 @@ This is [a link](/api/something) for you to click.
 
 ### Note
 
+You can render a simple note using the `>` character in front of your note. This will render a `Note` custom component (see below) with in a `note` variant and without a background.
+
 ```mdx
 > This is a note
 ```
@@ -97,6 +99,26 @@ For vertical images, the `BlockImage` component can be floated left or right:
 <BlockImage src={testImage} alt="Image alt text" align="right">
   This is a caption that I'd like to show for the image
 </BlockImage>;
+```
+
+### Note
+
+You can render notes in different styles depending on the needs. The variants map to the GitHub-style admonitions which are `note`, `tip`, `important`, `warning` and `caution`. These variants can be rendered with or without a heading.
+
+A note without any props render a simple `note` block:
+
+```js
+import { Note } from '@/components';
+
+<Note>This is something I want to say</Note>;
+```
+
+You can change the variant and heading by using the `variant` and `heading` component props:
+
+```js
+<Note variant="caution" heading="Be careful!">
+  This is something I want to say
+</Note>
 ```
 
 ### Cards

--- a/src/app/_styles/variables.css
+++ b/src/app/_styles/variables.css
@@ -23,11 +23,41 @@
     --base-color-grey-700: #39586a;
     --base-color-grey-900: #092f45;
     --base-color-grey-1000: #031c2b;
+    --base-color-purple-100: #f1eaff;
+    --base-color-purple-200: #e4d8ff;
+    --base-color-purple-300: #d6c3ff;
+    --base-color-purple-500: #915eff;
+    --base-color-purple-600: #7b4bdf;
+    --base-color-purple-700: #644dbf;
+    --base-color-red-50: #fff0f3;
+    --base-color-red-100: #fddfe7;
+    --base-color-red-200: #d6919f;
+    --base-color-red-500: #ff0c46;
+    --base-color-red-600: #dc2e4d;
+    --base-color-red-700: #b83b54;
+    --base-color-teal-50: #e4f8f0;
+    --base-color-teal-100: #c9f0e2;
+    --base-color-teal-200: #85dabb;
+    --base-color-teal-300: #76ccad;
+    --base-color-teal-400: #5daa8d;
+    --base-color-teal-600: #2a614d;
+    --base-color-yellow-50: #fff9e7;
+    --base-color-yellow-100: #ffecb3;
+    --base-color-yellow-200: #ffe082;
+    --base-color-yellow-300: #ffd54f;
+    --base-color-yellow-500: #eec26f;
+    --base-color-yellow-600: #ffa000;
+    --base-color-yellow-700: #ff8f00;
+    --base-color-yellow-800: #c87107;
 
     /* Backgrounds */
     --color-background-default: var(--base-color-white);
     --color-background-light: var(--base-color-grey-25);
-    --color-background-note: #deeafd; /* TODO: Align color with design system */
+    --color-background-info: var(--base-color-blue-100);
+    --color-background-alert: var(--base-color-red-100);
+    --color-background-premium: var(--base-color-purple-100);
+    --color-background-success: var(--base-color-teal-100);
+    --color-background-warning: var(--base-color-yellow-100);
     --color-background-code: var(--base-color-blue-75);
     --color-background-pre: var(--base-color-blue-1000);
 
@@ -36,6 +66,11 @@
     --color-text-secondary: var(--base-color-grey-600);
     --color-text-on-color: var(--base-color-white);
     --color-text-label: var(--base-color-grey-500);
+    --color-text-alert: var(--base-color-red-700);
+    --color-text-info: var(--base-color-grey-900);
+    --color-text-success: var(--base-color-teal-600);
+    --color-text-warning: var(--base-color-yellow-800);
+    --color-text-premium: var(--base-color-purple-600);
 
     /* Border */
     --color-border: var(--base-color-grey-300);

--- a/src/components/Card/Card.module.css
+++ b/src/components/Card/Card.module.css
@@ -2,7 +2,7 @@
   text-decoration: none;
   border-radius: var(--border-radius-2xl);
   background-color: var(--color-background-default);
-  border: 1px solid var(--color-background-note);
+  border: 1px solid var(--color-background-info);
   display: flex;
   flex-direction: column;
   gap: var(--space-s);

--- a/src/components/Note/Note.module.css
+++ b/src/components/Note/Note.module.css
@@ -1,21 +1,47 @@
-/* TODO: Adjust sizes in design system */
 .root {
+  background: var(--note-background);
+  color: var(--note-text);
   border-radius: var(--border-radius-s);
-  background: var(--color-background-note);
   padding-block: var(--space-s);
   padding-inline: var(--space-l);
   margin-block: var(--space-s);
   font-size: var(--text-body-s);
 }
-
 .root p:last-child {
   margin-block-end: 0;
 }
 
 .headline {
-  font-size: var(--text-headline-xs);
+  font-size: var(--text-headline-2xs);
   font-weight: bold;
   line-height: var(--text-body-l);
-  margin-block-end: var(--space-xs);
+  margin-block: var(--space-3xs) var(--space-2xs);
   letter-spacing: 0.08px;
+}
+
+/* Variants */
+
+.variantNote {
+  --note-background: var(--color-background-info);
+  --note-text: var(--color-text-info);
+}
+
+.variantTip {
+  --note-background: var(--color-background-success);
+  --note-text: var(--color-text-success);
+}
+
+.variantImportant {
+  --note-background: var(--color-background-premium);
+  --note-text: var(--color-text-premium);
+}
+
+.variantWarning {
+  --note-background: var(--color-background-warning);
+  --note-text: var(--color-text-warning);
+}
+
+.variantCaution {
+  --note-background: var(--color-background-alert);
+  --note-text: var(--color-text-alert);
 }

--- a/src/components/Note/Note.tsx
+++ b/src/components/Note/Note.tsx
@@ -1,14 +1,32 @@
+import { cva, VariantProps } from 'class-variance-authority';
 import styles from './Note.module.css';
 
-export function Note({ headline, children, ...rest }: NoteProps) {
+const note = cva(styles.root, {
+  variants: {
+    variant: {
+      note: styles.variantNote,
+      tip: styles.variantTip,
+      important: styles.variantImportant,
+      warning: styles.variantWarning,
+      caution: styles.variantCaution,
+    },
+  },
+  defaultVariants: {
+    variant: 'note',
+  },
+});
+
+export function Note({ variant, headline, children, ...rest }: NoteProps) {
   return (
-    <blockquote className={styles.root} {...rest}>
+    <blockquote className={note({ variant })} {...rest}>
       {headline && <p className={styles.headline}>{headline}</p>}
       {children}
     </blockquote>
   );
 }
 
-interface NoteProps extends React.ComponentPropsWithoutRef<'blockquote'> {
+type VariantsProps = VariantProps<typeof note>;
+
+interface NoteProps extends VariantsProps, React.ComponentPropsWithoutRef<'blockquote'> {
   headline?: string;
 }

--- a/src/content/test/index.mdx
+++ b/src/content/test/index.mdx
@@ -1,4 +1,4 @@
-import { BlockImage } from '@/components';
+import { BlockImage, Note } from '@/components';
 import horizontalImage from './images/horizontal.png';
 
 # Azure DevOps Integrations
@@ -146,8 +146,35 @@ oidcServiceSlug: '$(YOUR_SERVICE_SLUG)'
 - Under Service Accounts, select the appropriate service account(s) that this provider can authenticate with. For example, you might select a service account like “ado-user” as shown in the image above.
 - Click Create Settings to save the configuration.
 
-> [!NOTE]
-> This configuration allows Cloudsmith to authenticate requests from Azure DevOps using OIDC, provided the token claims match.
+<Note>
+  This configuration allows Cloudsmith to authenticate requests from Azure DevOps using OIDC, provided the
+  token claims match.
+</Note>
+
+<Note headline="Note">
+  This configuration allows Cloudsmith to authenticate requests from Azure DevOps using OIDC, provided the
+  token claims match.
+</Note>
+
+<Note variant="tip" headline="Tip">
+  This configuration allows Cloudsmith to authenticate requests from Azure DevOps using OIDC, provided the
+  token claims match.
+</Note>
+
+<Note variant="important" headline="Important">
+  This configuration allows Cloudsmith to authenticate requests from Azure DevOps using OIDC, provided the
+  token claims match.
+</Note>
+
+<Note variant="warning" headline="Warning">
+  This configuration allows Cloudsmith to authenticate requests from Azure DevOps using OIDC, provided the
+  token claims match.
+</Note>
+
+<Note variant="caution" headline="Caution">
+  This configuration allows Cloudsmith to authenticate requests from Azure DevOps using OIDC, provided the
+  token claims match.
+</Note>
 
 <BlockImage src={horizontalImage} alt="Edit provider settings">
   Jorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vulputate libero et velit interdum, ac aliquet

--- a/src/markdown/Paragraph/Paragraph.module.css
+++ b/src/markdown/Paragraph/Paragraph.module.css
@@ -4,7 +4,7 @@
   max-width: var(--text-max-width);
 }
 
-.root:first-of-type {
+article > .root:first-of-type {
   font-size: var(--text-body-l);
   line-height: var(--line-height-l);
   margin-block-end: var(--space-m);

--- a/src/mdx-components.tsx
+++ b/src/mdx-components.tsx
@@ -20,7 +20,7 @@ const components = {
 
   hr: (props: ComponentPropsWithoutRef<'hr'>) => <HorizontalRule {...props} />,
 
-  blockquote: (props: ComponentPropsWithoutRef<'blockquote'>) => <Note headline="Note:" {...props} />,
+  blockquote: (props: ComponentPropsWithoutRef<'blockquote'>) => <Note {...props} />,
 
   code: (props: ComponentPropsWithoutRef<'pre'>) => <Code {...props} />,
   pre: ({ children, ...props }: ComponentPropsWithoutRef<'pre'>) => {


### PR DESCRIPTION
This PR tweaks the style of the `Note` component to make available all the GitHub-style admonition variants. It also defaults the basic `>` note to render without the heading.