### PR TITLE
Removing content property from search results

### DIFF
--- a/src/lib/search/server.ts
+++ b/src/lib/search/server.ts
@@ -70,7 +70,9 @@ export const performSearch = async (
         .replace(/[^0-9a-z-A-Z \.\:]/g, '')
         .replace(/ +/, ' ');
 
-      const { content: _, ...rest } = item;
+      // Return everything but the content attribute
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { content, ...rest } = item;
 
       return {
         ...rest,


### PR DESCRIPTION
The `content` property in search results bogs down the size of the payload, so this PR removes it. I made sure that Typescript doesn't complain this time.