### PR TITLE
Better titles for API reference pages

### DIFF
--- a/src/components/AppShell/AppShell.module.css
+++ b/src/components/AppShell/AppShell.module.css
@@ -22,14 +22,13 @@
   }
 
   .secondaryNav {
-    position: initial;
     z-index: 0;
-    top: 0;
     flex: 0 0 var(--sidebar-width);
     border-right: 1px solid var(--color-border);
     border-left: 1px solid var(--color-border);
     background-color: var(--color-background-light);
-    min-height: calc(100vh - var(--navbar-height));
+    height: calc(100vh - var(--navbar-height));
+    overflow-y: auto;
   }
 
   .main {

--- a/src/lib/search/server.test.ts
+++ b/src/lib/search/server.test.ts
@@ -38,7 +38,7 @@ describe('lib', () => {
         const results = await performSearch('Lists audit log entries for a specific namespace', ['api']);
         expect(results[0].path).toEqual('/api/audit/log/namespace/list');
         // This will not test MDX frontmatter because of Jest mock
-        expect(results[0].title).toEqual('Missing headline for endpoint');
+        expect(results[0].title).toEqual('Audit Log Namespace List');
         expect(results[0].section).toEqual('api');
         expect(results[0].score).toEqual(1);
       });

--- a/src/lib/swagger/parse.test.ts
+++ b/src/lib/swagger/parse.test.ts
@@ -32,8 +32,7 @@ describe('lib', () => {
           expect(operation?.path).toEqual('/orgs');
           expect(operation?.method).toEqual('get');
           expect(operation?.slug).toEqual('orgs/list');
-          // TODO when summary property is in swagger
-          expect(operation?.title).toEqual('Missing headline for endpoint');
+          expect(operation?.title).toEqual('Orgs List');
         });
       });
 

--- a/src/lib/swagger/parse.ts
+++ b/src/lib/swagger/parse.ts
@@ -1,7 +1,7 @@
 import SwaggerParser from '@apidevtools/swagger-parser';
 import { OpenAPIV3 } from 'openapi-types';
 import { ApiOperation } from './types';
-import { isHttpMethod, createSlug, parseMenuSegments, apiOperationPath } from './util';
+import { isHttpMethod, createSlug, parseMenuSegments, apiOperationPath, createTitle } from './util';
 import { MenuItem } from '../menu/types';
 
 /**
@@ -39,8 +39,7 @@ export const toOperations = (schema: OpenAPIV3.Document): ApiOperation[] => {
           path,
           menuSegments,
           slug,
-          // TODO when summary property is in swagger
-          title: 'Missing headline for endpoint',
+          title: createTitle(menuSegments),
         });
       }
     }

--- a/src/lib/swagger/util.test.ts
+++ b/src/lib/swagger/util.test.ts
@@ -1,4 +1,4 @@
-import { createSlug, parseMenuSegments } from './util';
+import { createSlug, createTitle, parseMenuSegments } from './util';
 
 describe('lib', () => {
   describe('swagger', () => {
@@ -26,6 +26,19 @@ describe('lib', () => {
           ];
           for (const item of mapping) {
             expect(createSlug(item.from)).toEqual(item.to);
+          }
+        });
+      });
+      describe('createTItle', () => {
+        test('it creates proper slug', async () => {
+          const mapping = [
+            { from: ['Audit', 'Log', 'Namespace', 'List'], to: 'Audit Log Namespace List' },
+            { from: ['Badges', 'Version', 'List'], to: 'Badges Version List' },
+            { from: ['Billing', 'Account', 'Status'], to: 'Billing Account Status' },
+            { from: ['Billing', 'Invoices'], to: 'Billing Invoices' },
+          ];
+          for (const item of mapping) {
+            expect(createTitle(item.from)).toEqual(item.to);
           }
         });
       });

--- a/src/lib/swagger/util.ts
+++ b/src/lib/swagger/util.ts
@@ -37,6 +37,13 @@ export const createSlug = (menuSegments: string[]): string => {
 };
 
 /**
+ * Turns the menu segments into a single title for the operation page.
+ */
+export const createTitle = (menuSegments: string[]): string => {
+  return menuSegments.join(' ');
+};
+
+/**
  * Turns an operation slug into a fully qualified local path to use in links
  */
 export const apiOperationPath = (slug: string): string => {


### PR DESCRIPTION
This PR implements the title for the API reference pages. This is as good as we can do now without other information in the Swagger file. I also fixed the sidebar, so it scrolls on its own to not have the page jump on navigation.