### PR TITLE
Sort API resources and methods alphabetically

### DIFF
--- a/src/lib/swagger/parse.ts
+++ b/src/lib/swagger/parse.ts
@@ -185,5 +185,27 @@ export const toMenuItems = (operations: ApiOperation[]): MenuItem[] => {
     });
   };
 
-  return flattenMenuItems(items);
+  const sortMenuItems = (menuItems: MenuItem[]): MenuItem[] => {
+    return menuItems.slice().sort((a, b) => {
+      // Items with children should go first
+      if (a.children && !b.children) return -1;
+      if (!a.children && b.children) return 1;
+
+      // Otherwise, sort alphabetically
+      return a.title.localeCompare(b.title);
+    }).map((item) => {
+      if (item.children) {
+        const sortedChildren = sortMenuItems(item.children);
+        return {
+          ...item,
+          // Ensure that the parent item links to the first child in the sorted children
+          path: sortedChildren.find((child) => !child.children)?.path,
+          children: sortedChildren
+        };
+      }
+      return item;
+    });
+  };
+
+  return sortMenuItems(flattenMenuItems(items));
 };


### PR DESCRIPTION
This PR introduces sorting of the `/api` submenu according to these rules:

1. Any menu item with children is sorted first
2. Everything else is sorted alphabetically

@paulmay-cloudsmith This seems to work quite well, but keep in mind that this will discard the order from the original OpenApi documentation. It often leads to methods such as Delete being listed before List.

<img width="268" height="494" alt="Screenshot 2025-08-20 at 10 14 22" src="https://github.com/user-attachments/assets/4a790fbc-2156-48fd-8393-b26e5edc17eb" />
