### PR TITLE
style: added inline spacing to grid columns in api response grids

### DIFF
--- a/src/components/ApiMedia/ApiMedia.module.css
+++ b/src/components/ApiMedia/ApiMedia.module.css
@@ -47,10 +47,12 @@
 
 .responseGridColumn {
   --column-block-padding: var(--space-xs);
+  --column-inline-padding: var(--space-2xs);
 
   border-top: 1px solid var(--color-border);
 
   line-height: var(--line-height-s);
+  padding-inline: var(--column-inline-padding);
   padding-block: var(--column-block-padding);
 }
 


### PR DESCRIPTION
Noticed some spacing issues in the API response grid. Added some inline padding.

**Before**
<img width="851" height="494" alt="Screenshot 2025-08-21 at 14 06 01" src="https://github.com/user-attachments/assets/c1d08524-272a-411b-8ab0-a15de7ca3141" />


**After**
<img width="851" height="494" alt="Screenshot 2025-08-21 at 14 05 53" src="https://github.com/user-attachments/assets/4f1dad7d-592b-4fd3-bb6f-84ddf85fe89c" />
