### PR TITLE
Update getting-started.mdx

### DIFF
--- a/src/content/supply-chain-security/epm/getting-started.mdx
+++ b/src/content/supply-chain-security/epm/getting-started.mdx
@@ -75,7 +75,7 @@ It is advised to export the following variables such that they can be used in an
 
 ```shell
 export CLOUDSMITH_API_KEY=<YOUR_CLOUDSMITH_API_KEY>  
-export CLOUDSMITH_WORKPLACE-<YOUR_CLOUDSMITH_WORKSPACE>
+export CLOUDSMITH_WORKPLACE=<YOUR_CLOUDSMITH_WORKSPACE>
 ```
 
 Save the Rego policy created in Step 1 to a file named `policy.rego`. Then use the script below to create a JSON request body which includes the Rego content in the `rego` field:
@@ -143,6 +143,8 @@ curl -X POST "https://api.cloudsmith.io/v2/workspaces/$CLOUDSMITH_WORKPLACE/poli
   -d '{
     "action_type": "SetPackageState",
     "precedence": 1,
+    "package_state": "QUARANTINED"
+  }'
 
 ```
 


### PR DESCRIPTION
Corrected a typo in the environment variable export command in Step 2: [Create a policy using the API](https://docs.cloudsmith.com/supply-chain-security/epm/getting-started#adding-an-action-to-quarantine-a-package)

Changed export CLOUDSMITH_WORKPLACE-<YOUR_CLOUDSMITH_WORKSPACE> → export CLOUDSMITH_WORKPLACE=<YOUR_CLOUDSMITH_WORKSPACE>

Fixed invalid JSON in the curl example for creating a policy action in Step 3: Adding actions to a policy [Adding an action to quarantine a package](https://docs.cloudsmith.com/supply-chain-security/epm/getting-started#adding-an-action-to-quarantine-a-package)
1. Added missing "package_state": "QUARANTINED" field with proper quoting.