### PR TITLE
Policy Bulletin: Add recipes to address recent Chalk vulnerability

### DIFF
--- a/src/content/guides/mitigating-chalk-vulnerability/index.mdx
+++ b/src/content/guides/mitigating-chalk-vulnerability/index.mdx
@@ -1,0 +1,51 @@
+import { BlockImage, Note } from '@/components'
+
+# Policy Bulletin: Addressing Compromosed JS Package Chalk 5.6.1
+
+On September 8th 2025 we became aware of a [vulnerability in a widely-used JS library; Chalk](https://github.com/chalk/chalk/issues/656#issuecomment-3266894253). We are advising Cloudsmith customers to create additional policies to block the affected package and related libraries.
+
+## Policy 1: Blocks specific packages and versions
+
+```rego
+(format:npm) AND (
+    (name:^backslash$          AND version:^0.2.1$)
+ OR (name:^chalk-template$     AND version:^1.1.1$)
+ OR (name:^supports-hyperlinks$ AND version:^4.1.1$)
+ OR (name:^has-ansi$           AND version:^6.0.1$)
+ OR (name:^simple-swizzle$     AND version:^0.2.3$)
+))
+```
+
+## Policy 2: Blocks specific packages and versions
+
+```rego
+(format:npm) AND (
+    (name:^color-string$  AND version:^2.1.1$)
+ OR (name:^error-ex$      AND version:^1.3.3$)
+ OR (name:^color-name$    AND version:^2.0.1$)
+ OR (name:^is-arrayish$   AND version:^0.3.3$)
+ OR (name:^slice-ansi$    AND version:^7.1.1$)
+))
+```
+
+## Policy 3: Blocks specific packages and versions
+
+```rego
+(format:npm) AND (
+    (name:^color-convert$   AND version:^3.1.1$)
+ OR (name:^wrap-ansi$       AND version:^9.0.1$)
+ OR (name:^ansi-regex$      AND version:^6.2.1$)
+ OR (name:^supports-color$  AND version:^10.2.1$)
+ OR (name:^strip-ansi$      AND version:^7.1.1$)
+)
+```
+
+## Recipe 4: Blocks specific packages and versions
+
+```rego
+(format:npm) AND (
+    (name:^chalk$        AND version:^5.6.1$)
+ OR (name:^debug$        AND version:^4.4.2$)
+ OR (name:^ansi-styles$  AND version:^6.2.2$)
+)
+```


### PR DESCRIPTION
On September 8th 2025 we became aware of a [vulnerability in a widely-used JS library; Chalk](https://github.com/chalk/chalk/issues/656#issuecomment-3266894253). We are advising Cloudsmith customers to create additional policies to block the affected package and related libraries.
