### PR TITLE
correct name of EPM

### DIFF
--- a/src/content/about-cloudsmith/common-use-cases.mdx
+++ b/src/content/about-cloudsmith/common-use-cases.mdx
@@ -167,7 +167,7 @@ Ensuring the integrity and security of the software you build and use is paramou
 
 <Flex gap="s" align="stretch">
   <Card
-    title="Enterprise Policy Management"
+    title="Enterprise Policy Manager"
     description="Define granular, automated policies for vulnerability severity, license compliance, and more."
     href="/supply-chain-security/epm"
     icon="utility/documentation"

--- a/src/content/about-cloudsmith/key-concepts.mdx
+++ b/src/content/about-cloudsmith/key-concepts.mdx
@@ -38,7 +38,7 @@ Cloudsmith uses role-based access control (RBAC), API tokens, and service accoun
 
 ### Policies
 
-Repositories can enforce governance rules using Enterprise Policy Management (EPM). Policies can block artifacts, restrict usage based on licenses, or require provenance metadata before publication or distribution.
+Repositories can enforce governance rules using Enterprise Policy Manager (EPM). Policies can block artifacts, restrict usage based on licenses, or require provenance metadata before publication or distribution.
 
 ### Provenance and Metadata
 

--- a/src/content/guides/epm-rego-cookbook/index.mdx
+++ b/src/content/guides/epm-rego-cookbook/index.mdx
@@ -6,7 +6,7 @@ import styles from '../../../app/(documentation)/design-system/page.module.css';
 
 # Cloudsmith EPM Rego Policies Cookbook
 
-This cookbook provides a collection of Rego policy examples for Cloudsmith Enterprise Policy Management (EPM). These policies are designed to help enforce best practices, compliance, and security within your software supply chain.
+This cookbook provides a collection of Rego policy examples for Cloudsmith Enterprise Policy Manager (EPM). These policies are designed to help enforce best practices, compliance, and security within your software supply chain.
 
 If you are not a Cloudsmith user, these recipes still provide helpful guidance as it relates to thinking through software supply chain compliance and security and the role policy management can play. For a bit more background information on EPM, you can start with this [EPM overview blog](https://cloudsmith.com/blog/policy-as-code-automation-with-epm) and then come back to the cookbook afterward.
 

--- a/src/content/supply-chain-security/continuous-security.mdx
+++ b/src/content/supply-chain-security/continuous-security.mdx
@@ -5,7 +5,7 @@ import { Note } from '@/components'
 Continuous Security is a feature that provides an hourly feed of vulnerability and malicious package data from multiple sources (see [refresh intervals](#data-sources) for each source). Whenever vulnerabilities or malicious packages are published or modified, we match them to artifacts in your Cloudsmith repositories. This enables faster identification of affected artifacts compared to scheduled or on-demand [vulnerability scanning](./vulnerability-scanning).
 
 <Note variant="note" headline="Early Access">
-Continuous Security is in Early Access (EA) as part of the Cloudsmith's Enterprise Policy Management feature.
+Continuous Security is in Early Access (EA) as part of the Cloudsmith's Enterprise Policy Manager feature.
 </Note>
 
 ## Vulnerability Scanning vs. Continuous Security
@@ -17,12 +17,12 @@ Cloudsmith [scans](./vulnerability-scanning) artifacts as they are introduced in
 ### Continuous Security
 
 <Note variant="note" headline="EPM Required">
-Continuous Security is only available for Cloudsmith workspaces where Enterprise Policy Management (EPM) has been enabled.
+Continuous Security is only available for Cloudsmith workspaces where Enterprise Policy Manager (EPM) has been enabled.
 </Note>
 
 Continuous Security matches the software artifacts in your Repository with vulnerability data from several sources. Unlike Vulnerability Scanning, Continuous Security responds automatically in real time as vulnerabilities are reported or modified in those sources, with no manual effort required. Whenever a threat that affects an artifact in your workspace is detected, Continuous Security triggers EPM policy evaluation, with the vulnerability data included in the policy input.
 
-For more information about using EPM to address vulnerabilities identified by Continuous Security, see [Getting Started with Enterprise Policy Management](./epm/getting-started) and [Rego Recipes](./epm/rego).
+For more information about using EPM to address vulnerabilities identified by Continuous Security, see [Getting Started with Enterprise Policy Manager](./epm/getting-started) and [Rego Recipes](./epm/rego).
 
 Details of the specific vulnerability data available via Continuous Security are available in our API documentation under the vulnerabilities object in the [PolicyInputV0 schema](https://api.cloudsmith.io/v2/swagger/).
 

--- a/src/content/supply-chain-security/epm/getting-started.mdx
+++ b/src/content/supply-chain-security/epm/getting-started.mdx
@@ -1,12 +1,12 @@
 import { BlockImage, Note } from '@/components'
 
-# Getting Started with Enterprise Policy Management
+# Getting Started with Enterprise Policy Manager
 
-_An introduction to creating Enterprise policy management policies and actions._
+_An introduction to creating Enterprise Policy Manager policies and actions._
 
 ---
 
-This guide offers an introduction to creating Enterprise policy management policies and actions. Using this guide, you will:
+This guide offers an introduction to creating Enterprise Policy Manager policies and actions. Using this guide, you will:
 
 - Create policy matching logic using the Rego language to match packages above a specified vulnerability threshold.
 - Create a policy via the API that employs this matching logic.
@@ -212,4 +212,4 @@ The following will be provided within these logs:
 - `policy_output`: The results (match or not, partial rule states).
 - `actions`: The actions invoked against the package.
 
-For more information on building common matching criteria in Rego, please see the [Enterprise Policy Management Rego Recipes guide](rego).
+For more information on building common matching criteria in Rego, please see the [Enterprise Policy Manager Rego Recipes guide](rego).

--- a/src/content/supply-chain-security/epm/index.mdx
+++ b/src/content/supply-chain-security/epm/index.mdx
@@ -50,11 +50,11 @@ Actions can be assigned to policies to act on packages following policy evaluati
 - `add_package_tags`. Add a set of tags to the package.
 - Note on quarantining action: If you set the action to quarantine, any request for the package returns a **403 Forbidden** error code.
 
-For more detail on creating Enterprise policy management policies and actions, see the [Getting Started with Enterprise Policy Management guide](/supply-chain-security/epm/getting-started).
+For more detail on creating Enterprise Policy Manager policies and actions, see the [Getting Started with Enterprise Policy Manager guide](/supply-chain-security/epm/getting-started).
 
 ### Decision Logs
 
 The details of every policy evaluation and its outcome are captured in a decision log.  
 Decision logs record the result of policy evaluations, including why the decision was made and what actions were taken as a result. 
 
-The [Getting Started](/supply-chain-security/epm/getting-started) with Enterprise Policy Management guide provides more details on creating enterprise policy management policies and actions.
+The [Getting Started](/supply-chain-security/epm/getting-started) with Enterprise Policy Manager guide provides more details on creating Enterprise Policy Manager policies and actions.

--- a/src/content/supply-chain-security/epm/rego.mdx
+++ b/src/content/supply-chain-security/epm/rego.mdx
@@ -1,6 +1,6 @@
 import { BlockImage, Note } from '@/components'
 
-# Enterprise Policy Management: Rego Recipes
+# Enterprise Policy Manager: Rego Recipes
 
 ## Recipe 1: Simple Tag Check
 

--- a/src/content/supply-chain-security/epm/tag-addition-removal-flow.mdx
+++ b/src/content/supply-chain-security/epm/tag-addition-removal-flow.mdx
@@ -2,12 +2,12 @@ import { BlockImage, Note } from '@/components'
 
 ## Tag Addition and Removal
 
-_An example workflow for adding and removing tags with Enterprise Policy Management._
+_An example workflow for adding and removing tags with Enterprise Policy Manager._
 
 ---
 
 This example workflow will guide you through the process of adding and removing tags from packages 
-using Enterprise Policy Management policies and actions. Using this guide, you will:
+using Enterprise Policy Manager policies and actions. Using this guide, you will:
 
 
 - Create two policies and two associated actions. Our policies will check the maximum severity and exploitability of any vulnerabilities associated with a package
@@ -130,7 +130,7 @@ curl -X POST "https://api.cloudsmith.io/v2/workspaces/$CLOUDSMITH_WORKSPACE/poli
 
 ## Step 3. Testing our policy with the simulator
 
-We can test our policy using the Enterprise Policy Management policy simulator by passing the `POLICY_SLUG` to
+We can test our policy using the Enterprise Policy Manager policy simulator by passing the `POLICY_SLUG` to
 the simulator API endpoint as follows:
 
 ```shell

--- a/src/content/supply-chain-security/index.mdx
+++ b/src/content/supply-chain-security/index.mdx
@@ -11,7 +11,7 @@ In this section you can learn how to:
 - **License Compliance**: Automatically scan for and identify the licenses of your dependencies, ensuring compliance with your organization's policies.
 - **Digital Signatures**: Verify the integrity and authenticity of your software artifacts using GPG, PGP, and other signing standards.
 
-Adding to this, Enterprise Policy Management (EPM) and Continuous Security:
+Adding to this, Enterprise Policy Manager (EPM) and Continuous Security:
 
 - [Policy-as-Code](/supply-chain-security/epm/) (Early Access): The next evolution in policy management, using Open Policy Agent (OPA). This new feature allows you to define all your security and license compliance rules in rego. While our existing policy features remain fully supported, Policy-as-Code is intended to become the primary method for managing supply chain security rules at scale.
 - [Continuous Security](/supply-chain-security/continuous-security) (Early Access): Continuously monitor your dependencies to detect in real time and automatically act upon vulnerable and malicious packages.

--- a/src/content/supply-chain-security/malware-detection/malicious-packages.mdx
+++ b/src/content/supply-chain-security/malware-detection/malicious-packages.mdx
@@ -36,7 +36,7 @@ OSV.dev, initiated by Google, provides a unified, open, and distributed database
 Malicious package detection via OSV.dev is available for Ultra and Enterprise customers.
 </Note>
 
-The malicious packages dataset is integrated into [Enterprise Policy Management](/supply-chain-security/epm) and [Continuous Security](/supply-chain-security/continuous-security) (both in Early Access). This allows you to define policies that automatically take action when a malicious package is detected.
+The malicious packages dataset is integrated into [Enterprise Policy Manager](/supply-chain-security/epm) and [Continuous Security](/supply-chain-security/continuous-security) (both in Early Access). This allows you to define policies that automatically take action when a malicious package is detected.
 
 Here is an EPM policy that matches any package which has been flagged as malicious by Continuous Security, quarantines it, and adds a `MALICIOUS_PACKAGE` tag:
 


### PR DESCRIPTION
EPM should stand for Enterprise Policy Manager, but we sometimes call it "Enterprise policy management". I've updated this to "Manager" and also started using EPM once the term has been defined.