### PR TITLE
add(DOCS-263): clarify scope of deny policies for docker sbom

### DIFF
--- a/src/content/policy-management/deny-policy.mdx
+++ b/src/content/policy-management/deny-policy.mdx
@@ -23,6 +23,12 @@ Deny Policies allow users to specify criteria, in the form of a `package_query_s
 
 This feature applies to all formats.
 
+<Note variant="note" headline="Docker SBOM">
+Please, note that deny policies don't apply to components inside of a Docker image.
+
+While deny policies can be applied to docker images by its **package name** (pull string) or **image digest**, they won't apply to any of its internal components. For example, a deny policy with the next query: `format:python`, won't block docker images containing python artifacts within the Software Bill of Materials (SBOM).
+</Note>
+
 ## Scope
 
 Deny Policies are applied at the organization level.


### PR DESCRIPTION
Clarify our package deny rules user documentation on how they work with Docker + OCI images