### PR TITLE
Fixes typo in Swift registry docs

### DIFF
--- a/src/content/formats/swift-registry.mdx
+++ b/src/content/formats/swift-registry.mdx
@@ -201,7 +201,7 @@ To upload via the Cloudsmith CLI (or via API), you'll need to generate your pack
 swift package archive-source
 ```
 
-This will generate a zip file named `Alamofire.zip` that you can upload. Use the previous command to upload your new swift package via the Cloudsmith CLI and rememver to use a different version number (for example `5.9.2`):
+This will generate a zip file named `Alamofire.zip` that you can upload. Use the previous command to upload your new swift package via the Cloudsmith CLI and remember to use a different version number (for example `5.9.2`):
 
 ```shell
 cloudsmith push swift WORKSPACE/REPOSITORY PACKAGE_NAME.zip --name PACKAGE_NAME --version VERSION --scope SCOPE


### PR DESCRIPTION
Corrects 'rememver' to 'remember' in https://docs.cloudsmith.com/formats/swift-registry