### PR TITLE
chore(no-ticket): update bug bounty program link to use new docs site

### DIFF
--- a/src/content/customer-data-security.mdx
+++ b/src/content/customer-data-security.mdx
@@ -34,4 +34,4 @@ Cloudsmith’s architecture enforces a strict, application-managed process for e
 
 ## Vulnerability disclosure and Bug Bounty program
 
-Cloudsmith operates a [bug bounty program](https://help.cloudsmith.io/docs/bug-bounty-programme) to encourage responsible reporting of security issues. Reported bugs are investigated promptly. We appreciate your help in disclosing bugs to us privately, so that we can fix them before publishing technical details.
+Cloudsmith operates a [bug bounty program](https://docs.cloudsmith.com/resources/bug-bounty-program) to encourage responsible reporting of security issues. Reported bugs are investigated promptly. We appreciate your help in disclosing bugs to us privately, so that we can fix them before publishing technical details.


### PR DESCRIPTION
Moved docs site from help.cloudsmith.io to docs.cloudsmith.com