### PR TITLE
Added example of Cloudsmith CLI Github Release as the Generic Upstream

### DIFF
--- a/src/content/formats/generic-repository.mdx
+++ b/src/content/formats/generic-repository.mdx
@@ -268,26 +268,26 @@ The upstream prefix (`node_distributions`) ensures files from Node.js don't coll
 This example demonstrates how upstream URLs, prefixes, and file paths are applied when working with GitHub Releases.
 
 **Upstream configuration:**
-- **Upstream URL**: `https://api.github.com/repos/<owner>/<repo>/releases`
+- **Upstream URL**: `https://api.github.com/repos/cloudsmith-io/cloudsmith-cli/releases`
 - **Upstream Prefix**: `github_releases`
 
 **How paths are resolved:**
 
 The upstream URL includes the base path (`/releases/`), so file paths are relative to that location. 
-To download `https://github.com/aquasecurity/trivy/releases/download/v0.69.3/trivy_0.69.3_Linux-ARM64.tar.gz`, request the path `v0.69.3/trivy_0.69.3_Linux-ARM64.tar.gz` from Cloudsmith:
+To download `https://github.com/cloudsmith-io/cloudsmith-cli/releases/download/v1.16.0/cloudsmith.pyz`, request the path `download/v1.16.0/cloudsmith.pyz` from Cloudsmith:
 
 | Component | Value |
 | :-------- | :---- |
-| Upstream URL | `https://api.github.com/repos/aquasecurity/trivy/releases` |
-| File path on upstream | `v0.69.3/trivy_0.69.3_Linux-ARM64.tar.gz` |
-| Full upstream URL | `https://api.github.com/repos/aquasecurity/trivy/releases/v0.69.3/trivy_0.69.3_Linux-ARM64.tar.gz` |
+| Upstream URL | `https://api.github.com/repos/cloudsmith-io/cloudsmith-cli/releases` |
+| File path on upstream | `download/v1.16.0/cloudsmith.pyz` |
+| Full upstream URL | `https://api.github.com/repos/cloudsmith-io/cloudsmith-cli/releases/download/v1.16.0/cloudsmith.pyz` |
 | Upstream prefix | `github_releases` |
-| Cloudsmith URL | `https://generic.cloudsmith.io/OWNER/REPOSITORY/github_releases/v0.69.3/trivy_0.69.3_Linux-ARM64.tar.gz` |
+| Cloudsmith URL | `https://generic.cloudsmith.io/OWNER/REPOSITORY/github_releases/download/v1.16.0/cloudsmith.pyz` |
 
 **Download command:**
 
 ```shell
-curl -sLf -O 'https://generic.cloudsmith.io/OWNER/REPOSITORY/github_releases/v0.69.3/trivy_0.69.3_Linux-ARM64.tar.gz'
+curl -sLf -O 'https://generic.cloudsmith.io/OWNER/REPOSITORY/github_releases/download/v1.16.0/cloudsmith.pyz'
 ```
 
 ### Upstream Priority

--- a/src/content/formats/generic-repository.mdx
+++ b/src/content/formats/generic-repository.mdx
@@ -233,9 +233,11 @@ In the upstream creation menu, define a name for your upstream and enter the ups
 
 Please see our [Upstream Proxying](/repositories/upstreams#create-a-generic-upstream) documentation for further instructions on configuring upstreams.
 
-### Example: Node.js Distributions
+### Examples
 
-This example demonstrates how upstream URLs, prefixes, and file paths work together.
+#### Node.js Distributions
+
+This example demonstrates how upstream URLs, prefixes, and file paths are applied when working with Node.js distributions.
 
 **Upstream configuration:**
 - **Upstream URL**: `https://nodejs.org/dist/`
@@ -260,6 +262,33 @@ curl -sLf -O 'https://generic.cloudsmith.io/OWNER/REPOSITORY/node_distributions/
 ```
 
 The upstream prefix (`node_distributions`) ensures files from Node.js don't collide with files from other upstreams, even if they share identical file paths.
+
+#### Github Releases
+
+This example demonstrates how upstream URLs, prefixes, and file paths are applied when working with GitHub Releases.
+
+**Upstream configuration:**
+- **Upstream URL**: `https://api.github.com/repos/<owner>/<repo>/releases`
+- **Upstream Prefix**: `github_releases`
+
+**How paths are resolved:**
+
+The upstream URL includes the base path (`/releases/`), so file paths are relative to that location. 
+To download `https://github.com/aquasecurity/trivy/releases/download/v0.69.3/trivy_0.69.3_Linux-ARM64.tar.gz`, request the path `v0.69.3/trivy_0.69.3_Linux-ARM64.tar.gz` from Cloudsmith:
+
+| Component | Value |
+| :-------- | :---- |
+| Upstream URL | `https://api.github.com/repos/aquasecurity/trivy/releases` |
+| File path on upstream | `v0.69.3/trivy_0.69.3_Linux-ARM64.tar.gz` |
+| Full upstream URL | `https://api.github.com/repos/aquasecurity/trivy/releases/v0.69.3/trivy_0.69.3_Linux-ARM64.tar.gz` |
+| Upstream prefix | `github_releases` |
+| Cloudsmith URL | `https://generic.cloudsmith.io/OWNER/REPOSITORY/github_releases/v0.69.3/trivy_0.69.3_Linux-ARM64.tar.gz` |
+
+**Download command:**
+
+```shell
+curl -sLf -O 'https://generic.cloudsmith.io/OWNER/REPOSITORY/github_releases/v0.69.3/trivy_0.69.3_Linux-ARM64.tar.gz'
+```
 
 ### Upstream Priority
 

--- a/src/content/formats/generic-repository.mdx
+++ b/src/content/formats/generic-repository.mdx
@@ -280,7 +280,7 @@ To download `https://github.com/cloudsmith-io/cloudsmith-cli/releases/download/v
 | :-------- | :---- |
 | Upstream URL | `https://api.github.com/repos/cloudsmith-io/cloudsmith-cli/releases` |
 | File path on upstream | `download/v1.16.0/cloudsmith.pyz` |
-| Full upstream URL | `https://api.github.com/repos/cloudsmith-io/cloudsmith-cli/releases/download/v1.16.0/cloudsmith.pyz` |
+| Full upstream URL | `https://github.com/cloudsmith-io/cloudsmith-cli/releases/download/v1.16.0/cloudsmith.pyz` |
 | Upstream prefix | `github_releases` |
 | Cloudsmith URL | `https://generic.cloudsmith.io/OWNER/REPOSITORY/github_releases/download/v1.16.0/cloudsmith.pyz` |
 


### PR DESCRIPTION
As per the [ticket](https://cloudsmith-io.zendesk.com/agent/tickets/5852), Panu was facing an issue in configuring the Github repository as the generic upstream since there were no documentation for the reference.

Attached snapshots will show the preview of the documentation.

<img width="2442" height="1092" alt="image" src="https://github.com/user-attachments/assets/d32936c9-6211-4912-8888-385f9a019679" />


<img width="537" height="771" alt="image" src="https://github.com/user-attachments/assets/bdb8ecd8-323f-41dc-b2b9-6725799a86fc" />



