### PR TITLE
Update repository URLs in composer-repository.mdx

### DIFF
--- a/src/content/formats/composer-repository.mdx
+++ b/src/content/formats/composer-repository.mdx
@@ -110,7 +110,7 @@ When using HTTP Basic Authentication you'll probably want to keep your credentia
 ```json Username + Password
 {
   "http-basic": {
-    "dl.cloudsmith.io": {
+    "composer.cloudsmith.io": {
       "username": "USERNAME",
       "password": "PASSWORD"
     }
@@ -120,7 +120,7 @@ When using HTTP Basic Authentication you'll probably want to keep your credentia
 ```json Username + API-Key
 {
   "http-basic": {
-    "dl.cloudsmith.io": {
+    "composer.cloudsmith.io": {
       "username": "USERNAME",
       "password": "API-KEY"
     }
@@ -130,7 +130,7 @@ When using HTTP Basic Authentication you'll probably want to keep your credentia
 ```json Entitlement Token
 {
   "http-basic": {
-    "dl.cloudsmith.io": {
+    "composer.cloudsmith.io": {
       "username": "token",
       "password": "TOKEN"
     }


### PR DESCRIPTION
Fix Composer auth.json URL for Cloudsmith repository

- Changed auth.json URL from dl.cloudsmith.io to composer.cloudsmith.io
- Resolves login error in Zendesk ticket #6085
- Ensures proper authentication with Cloudsmith Composer repository