### PR TITLE
Add Go to supported Connected Repos docs

### DIFF
--- a/src/content/repositories/connected-repositories/index.mdx
+++ b/src/content/repositories/connected-repositories/index.mdx
@@ -6,7 +6,7 @@ import connectedRepoConnect from './images/connected-repository-connect.png'
 # Connected Repositories
 
 <Note variant="important" headline="Early Access">
-Connected Repositories are in Early Access (EA) and are currently supported for Maven, Docker, Python and NPM. Please contact us if you are interested in trying them.
+Connected Repositories are in Early Access (EA) and are currently supported for Maven, Docker, Python, NPM and Go. Please contact us if you are interested in trying them.
 </Note>
 
 Connected Repositories allow you to natively link multiple repositories together within a single repository, making packages from all connected repositories available through the repository that the connections are created on.
@@ -55,6 +55,7 @@ This mirrors the permission model used for upstreams.
 | Docker | ✅                              |
 | Python | ✅                              |
 | NPM    | ✅                              |
+| Go     | ✅                              |
 
 
 Support for additional formats is planned.


### PR DESCRIPTION
We now support Go format for connected repositories. Adding this to the docs