### PR TITLE
Add note about NPM upstream dist tags precedence setting.

### DIFF
--- a/src/content/formats/npm-registry.mdx
+++ b/src/content/formats/npm-registry.mdx
@@ -160,6 +160,12 @@ Cloudsmith has full support for distribution tags and (mostly) follows the same 
 5. When a package is copied/moved to another repository, its tags are carried with it.
 6. If the **latest** package is moved/deleted, then existing packages are sorted via SemVer to determine the next latest.
 
+<Note variant="note" headline="Upstream Tag Precedence">
+By default, the `latest` tag is given to the semantically highest version of a package within the native NPM responses. However, if you have an upstream configured and would like the `latest` tag defined on the upstream to take precedence, you can enable the **Npm Upstream Tags Take Precedence** option in your repository settings. This ensures that the `latest` tag from the upstream registry is used instead of the one from Cloudsmith.
+
+This is a common configuration for users who have an upstream to the public npm registry and want to ensure that the `latest` tag matches the response from the public registry.
+</Note>
+
 You can inspect a package to see what tags it has:
 
 ```shell


### PR DESCRIPTION
- Added a note within the NPM settings section to explain the newly added `Npm Upstreeam Tags Take Precedence` repository setting.

<img width="693" height="823" alt="image" src="https://github.com/user-attachments/assets/494ed2d7-786f-4b53-9035-5a62a99d4222" />
